### PR TITLE
Fixing scanning; passing in correct factory method

### DIFF
--- a/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AutoMapper.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -116,7 +116,7 @@ namespace AutoMapper
 
             services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(cfg => ConfigAction(sp, cfg)));
             services.Add(new ServiceDescriptor(typeof(IMapper),
-	            sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>()), serviceLifetime));
+	            sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService), serviceLifetime));
 
             return services;
         }

--- a/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
+++ b/test/AutoMapper.Extensions.Microsoft.DependencyInjection.Tests/DependencyTests.cs
@@ -13,7 +13,7 @@
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<ISomeService>(sp => new FooService(5));
-            services.AddAutoMapper(typeof(Source), typeof(Profile), typeof(Source));
+            services.AddAutoMapper(typeof(Source), typeof(Profile));
             _provider = services.BuildServiceProvider();
 
             _provider.GetService<IConfigurationProvider>().AssertConfigurationIsValid();


### PR DESCRIPTION
This fixes your tests by passing in the correct factory method to the `Mapper` constructor. See the before in your PR to see the `sp.GetService` method that the `Mapper` will use to instantiate dependencies. This is THE critical component to enable DI in AutoMapper